### PR TITLE
Simplify installation command, fix placeholder in 1_assets.ipynb

### DIFF
--- a/feo-client-examples/0_nodes.ipynb
+++ b/feo-client-examples/0_nodes.ipynb
@@ -25,7 +25,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --extra-index-url https://test.pypi.org/simple/ feo-client==0.0.1a7"
+    "!pip install --extra-index-url https://test.pypi.org/simple/ feo-client"
    ]
   },
   {

--- a/feo-client-examples/0_nodes.ipynb
+++ b/feo-client-examples/0_nodes.ipynb
@@ -25,7 +25,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ feo-client"
+    "!pip install --extra-index-url https://test.pypi.org/simple/ feo-client==0.0.1a7"
    ]
   },
   {

--- a/feo-client-examples/1_assets.ipynb
+++ b/feo-client-examples/1_assets.ipynb
@@ -25,7 +25,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --extra-index-url https://test.pypi.org/simple/ feo-client==0.0.1a7"
+    "!pip install --extra-index-url https://test.pypi.org/simple/ feo-client"
    ]
   },
   {

--- a/feo-client-examples/1_assets.ipynb
+++ b/feo-client-examples/1_assets.ipynb
@@ -25,7 +25,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ your-package"
+    "!pip install --extra-index-url https://test.pypi.org/simple/ feo-client==0.0.1a7"
    ]
   },
   {


### PR DESCRIPTION
### Description

Not sure if the more complicated installation line was intended, but this just uses TestPyPI as an extra index, not the default.

>Also pinning to the latest version of feo-client for now so that the notebooks are in working state out of the box. Should probably be unpinned once we have first proper release.

EDIT: removed this pin now that 0.0.0 has been yanked.

Also fixes placeholder package name in 1_assets.ipynb

### Checklist
- [x] Dependencies install correctly in a clean environment and code executes;
- [ ] Test coverage extended; created tests fail without the change (if possible)
- [ ] All tests passing;
- [ ] Commits follow a [type](https://gist.github.com/brianclements/841ea7bffdb01346392c#type) convention
- [ ] Extended the README, documentation and/or docstrings, if necessary;
