### PR TITLE
chore: pin feo-client version

### DIFF
--- a/feo-client-examples/0_nodes.ipynb
+++ b/feo-client-examples/0_nodes.ipynb
@@ -25,7 +25,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --extra-index-url https://test.pypi.org/simple/ feo-client"
+    "!pip install --extra-index-url https://test.pypi.org/simple/ feo-client==0.0.1a7"
    ]
   },
   {

--- a/feo-client-examples/1_assets.ipynb
+++ b/feo-client-examples/1_assets.ipynb
@@ -25,7 +25,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --extra-index-url https://test.pypi.org/simple/ feo-client"
+    "!pip install --extra-index-url https://test.pypi.org/simple/ feo-client==0.0.1a7"
    ]
   },
   {


### PR DESCRIPTION
### Description
Pins feo-client to version 0.0.1a7 to work around broken release 0.0.0

### Checklist
- [x] Dependencies install correctly in a clean environment and code executes;
- [ ] Test coverage extended; created tests fail without the change (if possible)
- [ ] All tests passing;
- [ ] Commits follow a [type](https://gist.github.com/brianclements/841ea7bffdb01346392c#type) convention
- [ ] Extended the README, documentation and/or docstrings, if necessary;
