### PR TITLE
refactor: upgrade to feo-client==0.0.1a8

### DIFF
--- a/feo-client-examples/0_nodes.ipynb
+++ b/feo-client-examples/0_nodes.ipynb
@@ -25,7 +25,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --extra-index-url https://test.pypi.org/simple/ feo-client==0.0.1a7"
+    "!pip install --extra-index-url https://test.pypi.org/simple/ feo-client==0.0.1a8"
    ]
   },
   {
@@ -153,7 +153,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "IDN = Node(\"IDN\")"
+    "IDN = Node.from_id(\"IDN\")"
    ]
   },
   {

--- a/feo-client-examples/1_assets.ipynb
+++ b/feo-client-examples/1_assets.ipynb
@@ -25,7 +25,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --extra-index-url https://test.pypi.org/simple/ feo-client==0.0.1a7"
+    "!pip install --extra-index-url https://test.pypi.org/simple/ feo-client==0.0.1a8"
    ]
   },
   {
@@ -120,7 +120,7 @@
    },
    "outputs": [],
    "source": [
-    "asset = Asset(\"PWRURNBGDA0U0\")\n",
+    "asset = Asset.from_id(\"PWRURNBGDA0U0\")\n",
     "asset.id, asset.name_primary_en"
    ]
   },


### PR DESCRIPTION
### Description

Upgrade feo-client to v0.0.1a8

Initialising assets and nodes by ID now requires the use of e.g. `Asset.from_id(id)`


### Checklist
- [ ] Dependencies install correctly in a clean environment and code executes;
- [ ] Test coverage extended; created tests fail without the change (if possible)
- [ ] All tests passing;
- [ ] Commits follow a [type](https://gist.github.com/brianclements/841ea7bffdb01346392c#type) convention
- [ ] Extended the README, documentation and/or docstrings, if necessary;
