### PR TITLE
chore: replace pinned install version with --pre flag

### DIFF
--- a/feo-client-examples/0_nodes.ipynb
+++ b/feo-client-examples/0_nodes.ipynb
@@ -25,7 +25,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --extra-index-url https://test.pypi.org/simple/ feo-client==0.0.1a9"
+    "!pip install --extra-index-url https://test.pypi.org/simple/ feo-client --pre"
    ]
   },
   {
@@ -33,9 +33,9 @@
    "execution_count": null,
    "id": "16eb2e8c-04df-4ede-8eb5-7a9e5621a2c6",
    "metadata": {
-      "tags": [
-          "skip-execution"
-      ]
+    "tags": [
+     "skip-execution"
+    ]
    },
    "outputs": [],
    "source": [
@@ -242,9 +242,9 @@
  ],
  "metadata": {
   "kernelspec": {
-"display_name": "python3",
+   "display_name": "python3",
    "language": "python",
-"name": "python3"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/feo-client-examples/1_assets.ipynb
+++ b/feo-client-examples/1_assets.ipynb
@@ -25,7 +25,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --extra-index-url https://test.pypi.org/simple/ feo-client==0.0.1a9"
+    "!pip install --extra-index-url https://test.pypi.org/simple/ feo-client --pre"
    ]
   },
   {
@@ -33,9 +33,9 @@
    "execution_count": null,
    "id": "751b4391-c15b-4cd3-bb27-730a13393b62",
    "metadata": {
-      "tags": [
-          "skip-execution"
-      ]
+    "tags": [
+     "skip-execution"
+    ]
    },
    "outputs": [],
    "source": [

--- a/feo-client-examples/2_technology_projections.ipynb
+++ b/feo-client-examples/2_technology_projections.ipynb
@@ -25,7 +25,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --extra-index-url https://test.pypi.org/simple/ feo-client==0.0.1a9"
+    "!pip install --extra-index-url https://test.pypi.org/simple/ feo-client --pre"
    ]
   },
   {
@@ -33,9 +33,9 @@
    "execution_count": null,
    "id": "77765e6c-9117-45d3-b143-131b88105b2a",
    "metadata": {
-      "tags": [
-          "skip-execution"
-      ]
+    "tags": [
+     "skip-execution"
+    ]
    },
    "outputs": [],
    "source": [

--- a/feo-client-examples/3_system_model_results.ipynb
+++ b/feo-client-examples/3_system_model_results.ipynb
@@ -25,7 +25,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --extra-index-url https://test.pypi.org/simple/ feo-client==0.0.1a9"
+    "!pip install --extra-index-url https://test.pypi.org/simple/ feo-client --pre"
    ]
   },
   {
@@ -33,9 +33,9 @@
    "execution_count": null,
    "id": "5bfacd0c-59cc-4715-8f26-20f5274c6226",
    "metadata": {
-      "tags": [
-          "skip-execution"
-      ]
+    "tags": [
+     "skip-execution"
+    ]
    },
    "outputs": [],
    "source": [


### PR DESCRIPTION
### Description
Replace feo-client version pin with `--pre` flag to always install latest pre-release.

### Checklist
- [x] Dependencies install correctly in a clean environment and code executes;
- [x] Test coverage extended; created tests fail without the change (if possible)
- [ ] All tests passing;
- [x] Commits follow a [type](https://gist.github.com/brianclements/841ea7bffdb01346392c#type) convention
- [x] Extended the README, documentation and/or docstrings, if necessary;
