### PR TITLE
[ENG-394] feat: include notebooks in docs

### DIFF
--- a/feo-client-examples/index.md
+++ b/feo-client-examples/index.md
@@ -1,0 +1,58 @@
+[![License][license badge]][license]
+[![Contributor Covenant][contributor covenant badge]][code of conduct]
+
+[code of conduct]: https://github.com/transition-zero/tz-cookiecutter/blob/main/CODE-OF-CONDUCT.md
+[contributor covenant badge]: https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg
+[license badge]: https://img.shields.io/badge/License-Apache_2.0-blue.svg
+[license]: https://opensource.org/licenses/Apache-2.0
+<!-- badges-end -->
+
+# FEO Client Examples
+
+### Description
+
+A repo for examples for the FEO Python client.
+
+### Install
+**Status:** Required by default, optional for [documentation repositories](#definitions).
+
+**Requirements:**
+- Code block illustrating how to install.
+
+**Subsections:**
+- `Dependencies`. Required if there are unusual dependencies or dependencies that must be manually installed.
+
+**Suggestions:**
+- Link to prerequisite sites for programming language: [npmjs](https://npmjs.com), [godocs](https://godoc.org), etc.
+- Include any system-specific information needed for installation.
+- An `Updating` section would be useful for most packages, if there are multiple versions which the user may interface with.
+
+### Usage
+**Status:** Required by default, optional for [documentation repositories](#definitions).
+
+**Requirements:**
+- Code block illustrating common usage.
+- If CLI compatible, code block indicating common usage.
+- If importable, code block indicating both import functionality and usage.
+
+**Subsections:**
+- `CLI`. Required if CLI functionality exists.
+
+**Suggestions:**
+- Cover basic choices that may affect usage: for instance, if JavaScript, cover promises/callbacks, ES6 here.
+- If relevant, point to a runnable file for the usage code.
+
+
+### Contributing
+**Status**: Required.
+
+**Requirements:**
+- State where users can ask questions.
+- State whether PRs are accepted.
+- List any requirements for contributing; for instance, having a sign-off on commits.
+
+
+
+### License
+
+[Apache license 2.0](LICENSE)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,24 @@
+site_name: FEO Client Examples
+docs_dir: feo-client-examples
+
+plugins:
+- search
+- mkdocstrings
+- mkdocs-jupyter
+
+nav:
+  - Home: index.md
+  - Nodes: 0_nodes.ipynb
+  - Assets: 1_assets.ipynb
+  - 'Technology Projections': 2_technology_projections.ipynb
+  - 'System Model Results': 3_system_model_results.ipynb
+  - 'Geometries': 4_geometries.ipynb
+repo_url: https://github.com/transition-zero/feo-client-examples
+
+theme:
+  name: material
+  favicon: https://images.squarespace-cdn.com/content/v1/63d1607c35efbd5cbfee1529/294783be-8cea-4002-8dc7-c3c7842c0401/favicon.ico?format=100w
+  logo: https://feo.transitionzero.org/brand/logo_short_white.svg
+  features:
+    - header.autohide
+    - navigation.tabs


### PR DESCRIPTION
### Description
This is needed for allow our docs read and include the notebooks. See https://github.com/jdoiro3/mkdocs-multirepo-plugin

This way new notebooks included in mkdocs config will show up in docs

### Checklist
- [x] Dependencies install correctly in a clean environment and code executes;
- [ ] Test coverage extended; created tests fail without the change (if possible)
- [ ] All tests passing;
- [x] Commits follow a [type](https://gist.github.com/brianclements/841ea7bffdb01346392c#type) convention
- [x] Extended the README, documentation and/or docstrings, if necessary;
