### PR TITLE
fix: display shapely object instead of big geojson string

### DIFF
--- a/feo-client-examples/0_nodes.ipynb
+++ b/feo-client-examples/0_nodes.ipynb
@@ -206,7 +206,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "IDN.geometry"
+    "IDN.geometry.to_shape()"
    ]
   },
   {


### PR DESCRIPTION
### Description
Display shapely object when inspecting IDN.geometry in 0_assets instead of big geojson string

### Checklist
- [x] Dependencies install correctly in a clean environment and code executes;
- [x] Test coverage extended; created tests fail without the change (if possible)
- [ ] All tests passing;
- [x] Commits follow a [type](https://gist.github.com/brianclements/841ea7bffdb01346392c#type) convention
- [x] Extended the README, documentation and/or docstrings, if necessary;
