### PR TITLE
refactor: print nodes directly now we have custom __str__ methods

### DIFF
--- a/feo-client-examples/0_nodes.ipynb
+++ b/feo-client-examples/0_nodes.ipynb
@@ -225,7 +225,7 @@
    "outputs": [],
    "source": [
     "for child in IDN.children:\n",
-    "    print(child.id, child.name_primary_en)"
+    "    print(child)"
    ]
   },
   {
@@ -236,7 +236,7 @@
    "outputs": [],
    "source": [
     "for parent in IDN.parents:\n",
-    "    print(parent.id, parent.name_primary_en)"
+    "    print(parent)"
    ]
   }
  ],


### PR DESCRIPTION
### Description
Print nodes directly in 0_nodes now we have custom __str__ methods

### Checklist
- [x] Dependencies install correctly in a clean environment and code executes;
- [x] Test coverage extended; created tests fail without the change (if possible)
- [ ] All tests passing;
- [x] Commits follow a [type](https://gist.github.com/brianclements/841ea7bffdb01346392c#type) convention
- [x] Extended the README, documentation and/or docstrings, if necessary;
