### PR TITLE
fix: typos in 1_assets

### DIFF
--- a/feo-client-examples/1_assets.ipynb
+++ b/feo-client-examples/1_assets.ipynb
@@ -148,7 +148,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "asset.properties"
+    "asset.asset_properties"
    ]
   },
   {
@@ -177,7 +177,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "collection = AssetCollection.from_parent_node(\"IDN-JW\")"
+    "collection = AssetCollection.from_parent_node(\"POL\")  # Poland"
    ]
   },
   {
@@ -195,7 +195,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "collection.size, collection.columns"
+    "collection"
    ]
   },
   {


### PR DESCRIPTION
### Description
Fix a few typos in 1_assets.ipynb

### Checklist
- [x] Dependencies install correctly in a clean environment and code executes;
- [x] Test coverage extended; created tests fail without the change (if possible)
- [ ] All tests passing;
- [x] Commits follow a [type](https://gist.github.com/brianclements/841ea7bffdb01346392c#type) convention
- [x] Extended the README, documentation and/or docstrings, if necessary;
