### PR TITLE
fix: update colab link to renamed notebook

### DIFF
--- a/feo-client-examples/4_geospatial_data.ipynb
+++ b/feo-client-examples/4_geospatial_data.ipynb
@@ -13,7 +13,7 @@
    "id": "b1d45911-c183-4916-84a7-735da5464da9",
    "metadata": {},
    "source": [
-    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/transition-zero/feo-client-examples/blob/main/feo-client-examples/4_geometries.ipynb\">\n",
+    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/transition-zero/feo-client-examples/blob/main/feo-client-examples/4_geospatial_data.ipynb\">\n",
     "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
     "</a>"
    ]

--- a/feo-client-examples/4_geospatial_data.ipynb
+++ b/feo-client-examples/4_geospatial_data.ipynb
@@ -107,7 +107,7 @@
    "id": "1c99cb1b-862b-4aff-9879-b09db43c843e",
    "metadata": {},
    "source": [
-    "For a more detailed exploration of Nodes see the [Nodes](./0_nodes.ipynb) notebook."
+    "For a more detailed exploration of Nodes see the [Nodes](https://github.com/transition-zero/feo-client-examples/blob/main/feo-client-examples/0_nodes.ipynb) notebook."
    ]
   },
   {

--- a/feo-client-examples/4_geospatial_data.ipynb
+++ b/feo-client-examples/4_geospatial_data.ipynb
@@ -107,7 +107,7 @@
    "id": "1c99cb1b-862b-4aff-9879-b09db43c843e",
    "metadata": {},
    "source": [
-    "For a more detailed exploration of Nodes see the [Nodes](0_nodes.ipynb) notebook."
+    "For a more detailed exploration of Nodes see the [Nodes](./0_nodes.ipynb) notebook."
    ]
   },
   {


### PR DESCRIPTION
### Description
The link embedded in the colab button still had the old notebook name. Updated to point to the new notebook name.

### Checklist
- [x] Dependencies install correctly in a clean environment and code executes;
- [x] Test coverage extended; created tests fail without the change (if possible)
- [x] All tests passing;
- [x] Commits follow a [type](https://gist.github.com/brianclements/841ea7bffdb01346392c#type) convention
- [x] Extended the README, documentation and/or docstrings, if necessary;
