### PR TITLE
feat: demo Run.results.node_capacity

### DIFF
--- a/feo-client-examples/3_system_model_results.ipynb
+++ b/feo-client-examples/3_system_model_results.ipynb
@@ -74,7 +74,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from feo.client import Model, Scenario, Run"
+    "from feo.client import Model, Run, Scenario"
    ]
   },
   {
@@ -245,8 +245,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "node_capacity = coal_retirement_demo_run.results.node_capacity,
-    "node_capacity[(node_capacity.node_id == \"IDN-JB\") & (node_capacity.technology_type == \"COA\")]",
+    "node_capacity = coal_retirement_demo_run.results.node_capacitynode_capacity[\n",
+    "    (node_capacity.node_id == \"IDN-JB\") & (node_capacity.technology_type == \"COA\")\n",
+    "]"
    ]
   }
  ],

--- a/feo-client-examples/3_system_model_results.ipynb
+++ b/feo-client-examples/3_system_model_results.ipynb
@@ -245,9 +245,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "node_capacity = coal_retirement_demo_run.results.node_capacitynode_capacity[\n",
+    "node_capacity = coal_retirement_demo_run.results.node_capacity[\n",
     "    (node_capacity.node_id == \"IDN-JB\") & (node_capacity.technology_type == \"COA\")\n",
-    "]"
+    "]\n",
+    "node_capacity"
    ]
   }
  ],

--- a/feo-client-examples/3_system_model_results.ipynb
+++ b/feo-client-examples/3_system_model_results.ipynb
@@ -245,10 +245,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "node_capacity = coal_retirement_demo_run.results.node_capacity[\n",
+    "node_capacity = coal_retirement_demo_run.results.node_capacity\n",
+    "node_capacity[\n",
     "    (node_capacity.node_id == \"IDN-JB\") & (node_capacity.technology_type == \"COA\")\n",
-    "]\n",
-    "node_capacity"
+    "]"
    ]
   }
  ],

--- a/feo-client-examples/3_system_model_results.ipynb
+++ b/feo-client-examples/3_system_model_results.ipynb
@@ -182,8 +182,71 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "net_zero_scenario = Scenario.from_id(\"feo-global-indonesia:net-zero-2060\")\n",
-    "net_zero_demo_run = Run.from_id(\"feo-global-indonesia:net-zero-2060:main\")"
+    "coal_retirement_scenario = Scenario.from_id(\"feo-global-indonesia:coal-retirement\")\n",
+    "coal_retirement_demo_run = Run.from_id(\"feo-global-indonesia:coal-retirement:main\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2761c538-2d51-488e-aa1e-2c88f60ff848",
+   "metadata": {},
+   "source": [
+    "## Run Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2e033423-a9bd-41d4-95bb-6169c78fb47b",
+   "metadata": {},
+   "source": [
+    "System model results can be obtained from the `Run.results` object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "62bf535a-4f58-485a-bb62-1f8bfa81e504",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "coal_retirement_demo_run.results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16c3225a-12a0-4845-b5d3-171599370528",
+   "metadata": {},
+   "source": [
+    "For capacity expansion models, the results object has `node_capacity` and `edge_capacity` data. Each data type is exposed via a `ResultsCollection` object on `Run.results`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "29562e2a-cde5-4727-b07b-8d30e3983121",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "coal_retirement_demo_run.results.node_capacity"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24acb208-a1c8-48bc-b821-efecb4222d12",
+   "metadata": {},
+   "source": [
+    "Each `ResultsCollection` object can be filtered according to the `node` or `edge` that is of interest, particular technologies in the case of `capacity` or `production`, or particular commodities in the case of `trade` or `price`. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c4090d7b-c66b-4b41-8821-b7a116080509",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "node_capacity = coal_retirement_demo_run.results.node_capacity,
+    "node_capacity[(node_capacity.node_id == \"IDN-JB\") & (node_capacity.technology_type == \"COA\")]",
    ]
   }
  ],

--- a/feo-client-examples/3_system_model_results.ipynb
+++ b/feo-client-examples/3_system_model_results.ipynb
@@ -146,7 +146,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "idn_model.scenarios"
+    "for scenario in idn_model.scenarios:\n",
+    "    print(scenario)"
    ]
   },
   {
@@ -164,7 +165,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "run = idn_model.scenarios[0].runs"
+    "scenario = idn_model.scenarios[1]\n",
+    "for run in scenario.runs:\n",
+    "    print(run)"
    ]
   },
   {
@@ -268,7 +271,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
### Description
Adds a quick demo of Run.results.node_capacity for a coal retirement run. Note that this required the demo run being shown since the net zero run does not have attached capacity data.

Also made some small cosmetic changes.

### Checklist
- [x] Dependencies install correctly in a clean environment and code executes;
- [x] Test coverage extended; created tests fail without the change (if possible)
- [x] All tests passing;
- [x] Commits follow a [type](https://gist.github.com/brianclements/841ea7bffdb01346392c#type) convention
- [x] Extended the README, documentation and/or docstrings, if necessary;
