### PR TITLE
Fix: changed time filter to 2020

### DIFF
--- a/feo-client-examples/2_technology_projections.ipynb
+++ b/feo-client-examples/2_technology_projections.ipynb
@@ -145,7 +145,7 @@
    "outputs": [],
    "source": [
     "gas_combined_cycle.projections.loc[\n",
-    "    gas_combined_cycle.projections.valid_timestamp_start > \"2030-01-01\"\n",
+    "    gas_combined_cycle.projections.valid_timestamp_start > \"2020-01-01\"\n",
     "]"
    ]
   },
@@ -165,14 +165,6 @@
    "outputs": [],
    "source": [
     "record = gas_combined_cycle.projections.iloc[0].to_records()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2bbcbbb0-fdfd-4c5a-8d01-5b3e1cf9e471",
-   "metadata": {},
-   "source": [
-    "Like other types of records, technology projections have data provenance. Records have a `source` and a `publisher`."
    ]
   }
  ],


### PR DESCRIPTION
### Description

Currently  we apply a filter on the `valid_timestamp_start` for `gas_combined_cycle.projections` that returns an empty dataframe. I've updated the `valid_timestamp_start` we filter on to be an earlier date so that we don't filter all the records.

### Checklist
- [ ] Dependencies install correctly in a clean environment and code executes;
- [ ] Test coverage extended; created tests fail without the change (if possible)
- [ ] All tests passing;
- [ ] Commits follow a [type](https://gist.github.com/brianclements/841ea7bffdb01346392c#type) convention
- [ ] Extended the README, documentation and/or docstrings, if necessary;
