### PR TITLE
Fix: nbmake timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,4 +56,5 @@ jobs:
     - name: Test with pytest --nbmake
       run: |
         pip install pytest nbmake
-        pytest --nbmake feo-client-examples/*.ipynb
+        pytest --nbmake --nbmake-timeout=60 feo-client-examples/*.ipynb 
+        


### PR DESCRIPTION
### Description
Increases the cell timeout for nbmake to 60 seconds for each cell. 

### Checklist
- [x] Dependencies install correctly in a clean environment and code executes;
- [x] Test coverage extended; created tests fail without the change (if possible)
- [ ] All tests passing;
- [x] Commits follow a [type](https://gist.github.com/brianclements/841ea7bffdb01346392c#type) convention
- [x] Extended the README, documentation and/or docstrings, if necessary;
